### PR TITLE
Add close button to filter menu for better mobile & desktop UX

### DIFF
--- a/roblox/design.css
+++ b/roblox/design.css
@@ -2510,6 +2510,20 @@ button {
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
+.fltr-drwr-hdr #fasfa-times {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  cursor: pointer;
+  font-size: 1.5rem;
+  color: var(--txt-mut);
+  transition: color 0.3s ease;
+}
+
+.fltr-drwr-hdr #fasfa-times:hover {
+  color: var(--prim);
+}
+
 .fltr-drwr-ttl {
   font-size: 1.5rem;
   font-weight: 700;

--- a/roblox/funcs.js
+++ b/roblox/funcs.js
@@ -634,6 +634,7 @@ const DOM = {
       mobileFilterButton: "#mobFltrBtn",
       drawer: "#fltrDrwr",
       applyButton: "#applyFltrs",
+      closeButton: "#fasfa-times",
       levelSlider: "#lvlSldr",
       mobileLevelSlider: "#mobLvlSldr",
       levelValue: "#lvlMaxVal",
@@ -828,6 +829,7 @@ const UIManager = {
     const mobileFilterButton = DOM.get("mobileFilterButton")
     const drawer = DOM.get("drawer")
     const applyButton = DOM.get("applyButton")
+    const closeButton = DOM.get("closeButton")
 
     if (filterButton && drawer) {
       filterButton.addEventListener("click", () => {
@@ -859,6 +861,13 @@ const UIManager = {
 
     if (applyButton && drawer) {
       applyButton.addEventListener("click", () => {
+        drawer.classList.remove("open")
+        document.body.style.overflow = ""
+      })
+    }
+
+    if (closeButton && drawer) {
+      closeButton.addEventListener("click", () => {
         drawer.classList.remove("open")
         document.body.style.overflow = ""
       })

--- a/roblox/index.html
+++ b/roblox/index.html
@@ -383,6 +383,7 @@
     <div class="fltr-drwr-ovl"></div>
     <div class="fltr-drwr-cntnt">
       <div class="fltr-drwr-hdr">
+        <i id="fasfa-times" class="fas fa-times"></i>
         <h2 class="fltr-drwr-ttl">Filters</h2>
         <p class="fltr-drwr-desc">Adjust your search criteria to find the perfect exploit.</p>
       </div>


### PR DESCRIPTION
Added a close (X) button to the filter menu to improve UX.

Users previously had to click “Apply Filters” to exit or tap outside the card, which was unclear and clunky especially on mobile. This adds a clear way to close the menu without applying changes.