### PR TITLE
Change Kernel's sUNC to 92%

### DIFF
--- a/roblox/funcs.js
+++ b/roblox/funcs.js
@@ -896,7 +896,7 @@ info: "## Exploit Performance  \n- [Potassium](/) offers a smooth experience and
     lvl: 2,
     price: "FREE",
     plat: ["windows", "macos", "ios", "android"],
-    pros: ["87% sUNC (v1)"],
+    pros: ["92% sUNC (v1)"],
     neutral: ["Is a module for two games", "Level 2"],
     cons: [],
     verified: true,


### PR DESCRIPTION
* changed Kernel's sUNC to 92%, here's the results dumped: https://api.rubis.app/v2/scrap/AdbtZX2pP9CxpyTD/raw (loadstring works but fails due to my redirector server being booty)